### PR TITLE
toolchains: introduce wrapper

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -10,8 +10,9 @@ lib.makeScope newScope (
       maintainers = import ./maintainer-list.nix;
     };
 
+    toolchains = callPackage ./toolchains {};
     inherit
-      (callPackage ./toolchains {})
+      (self.toolchains)
       noobkitARM
       noobkitPPC
       noobkitA64

--- a/pkgs/toolchains/default.nix
+++ b/pkgs/toolchains/default.nix
@@ -7,7 +7,7 @@ lib.makeScope newScope (
     inherit (self) callPackage;
     mkToolchain = args: callPackage (import ./generic.nix args) {};
   in {
-    noobkitARM = mkToolchain rec {
+    noobkitARM-unwrapped = mkToolchain rec {
       pname = "noobkitARM";
       version = "65";
       srcs = {
@@ -30,6 +30,10 @@ lib.makeScope newScope (
       };
       variant = 1;
       archName = "ARM";
+    };
+
+    noobkitARM = callPackage ./wrapper.nix {
+      unwrapped = self.noobkitARM-unwrapped;
     };
 
     noobkitPPC = mkToolchain rec {

--- a/pkgs/toolchains/default.nix
+++ b/pkgs/toolchains/default.nix
@@ -1,81 +1,85 @@
 {
   lib,
-  callPackage,
-}: let
-  mkToolchain = args: callPackage (import ./generic.nix args) {};
-in {
-  noobkitARM = mkToolchain rec {
-    pname = "noobkitARM";
-    version = "65";
-    srcs = {
-      buildscripts = {
-        rev = "devkitARM_r${version}";
-        hash = "sha256-HBZX+lEw76GXA05GdjCWMaE/kqO8YJV55rOkVbNyxeQ=";
+  newScope,
+}:
+lib.makeScope newScope (
+  self: let
+    inherit (self) callPackage;
+    mkToolchain = args: callPackage (import ./generic.nix args) {};
+  in {
+    noobkitARM = mkToolchain rec {
+      pname = "noobkitARM";
+      version = "65";
+      srcs = {
+        buildscripts = {
+          rev = "devkitARM_r${version}";
+          hash = "sha256-HBZX+lEw76GXA05GdjCWMaE/kqO8YJV55rOkVbNyxeQ=";
+        };
+        binutils = {
+          version = "2.43.1";
+          hash = "sha256-vsqsXSleA3WHtjpC+tV/49nXuD9HjrJLZ/nuxdDxhy8=";
+        };
+        gcc = {
+          version = "14.2.0";
+          hash = "sha256-p7Obxpy/niWCbFpgqyZHcAH3wI2FzsBLwOKcq+1vPMk=";
+        };
+        newlib = {
+          version = "4.4.0.20231231";
+          hash = "sha256-DBZqOeG/CVHfr81olJ/g5LbTZYCB1igvOa7vxjEPLxM=";
+        };
       };
-      binutils = {
-        version = "2.43.1";
-        hash = "sha256-vsqsXSleA3WHtjpC+tV/49nXuD9HjrJLZ/nuxdDxhy8=";
-      };
-      gcc = {
-        version = "14.2.0";
-        hash = "sha256-p7Obxpy/niWCbFpgqyZHcAH3wI2FzsBLwOKcq+1vPMk=";
-      };
-      newlib = {
-        version = "4.4.0.20231231";
-        hash = "sha256-DBZqOeG/CVHfr81olJ/g5LbTZYCB1igvOa7vxjEPLxM=";
-      };
+      variant = 1;
+      archName = "ARM";
     };
-    variant = 1;
-    archName = "ARM";
-  };
 
-  noobkitPPC = mkToolchain rec {
-    pname = "noobkitPPC";
-    version = "45.2";
-    srcs = {
-      buildscripts = {
-        rev = "devkitPPC_r${version}";
-        hash = "sha256-n5voe1Gc4p7Xn9kO4pfI26aeSQFneyZypnCSYMcO2gw=";
+    noobkitPPC = mkToolchain rec {
+      pname = "noobkitPPC";
+      version = "45.2";
+      srcs = {
+        buildscripts = {
+          rev = "devkitPPC_r${version}";
+          hash = "sha256-n5voe1Gc4p7Xn9kO4pfI26aeSQFneyZypnCSYMcO2gw=";
+        };
+        binutils = {
+          version = "2.42";
+          hash = "sha256-qlSFDr2lBkxyzU7C2bBWwpQlKZFIY1DZqXqypt/frxI=";
+        };
+        gcc = {
+          version = "13.2.0";
+          hash = "sha256-4nXnZEKmBnNBon8Exca4PYYTFEAEwEE1KIY9xrXHQ9o=";
+        };
+        newlib = {
+          version = "4.4.0.20231231";
+          hash = "sha256-DBZqOeG/CVHfr81olJ/g5LbTZYCB1igvOa7vxjEPLxM=";
+        };
       };
-      binutils = {
-        version = "2.42";
-        hash = "sha256-qlSFDr2lBkxyzU7C2bBWwpQlKZFIY1DZqXqypt/frxI=";
-      };
-      gcc = {
-        version = "13.2.0";
-        hash = "sha256-4nXnZEKmBnNBon8Exca4PYYTFEAEwEE1KIY9xrXHQ9o=";
-      };
-      newlib = {
-        version = "4.4.0.20231231";
-        hash = "sha256-DBZqOeG/CVHfr81olJ/g5LbTZYCB1igvOa7vxjEPLxM=";
-      };
+      variant = 2;
+      archName = "PowerPC";
     };
-    variant = 2;
-    archName = "PowerPC";
-  };
 
-  noobkitA64 = mkToolchain rec {
-    pname = "noobkitA64";
-    version = "27";
-    srcs = {
-      buildscripts = {
-        rev = "devkitA64_r${version}";
-        hash = "sha256-Zr+BVIUNq2U9UE3/1rGFwKAJr3SNZ85jhsBfk98mgqM=";
+    noobkitA64 = mkToolchain rec {
+      pname = "noobkitA64";
+      version = "27";
+      srcs = {
+        buildscripts = {
+          rev = "devkitA64_r${version}";
+          hash = "sha256-Zr+BVIUNq2U9UE3/1rGFwKAJr3SNZ85jhsBfk98mgqM=";
+        };
+        binutils = {
+          version = "2.43.1";
+          hash = "sha256-vsqsXSleA3WHtjpC+tV/49nXuD9HjrJLZ/nuxdDxhy8=";
+        };
+        gcc = {
+          version = "14.2.0";
+          hash = "sha256-p7Obxpy/niWCbFpgqyZHcAH3wI2FzsBLwOKcq+1vPMk=";
+        };
+        newlib = {
+          version = "4.4.0.20231231";
+          hash = "sha256-DBZqOeG/CVHfr81olJ/g5LbTZYCB1igvOa7vxjEPLxM=";
+        };
       };
-      binutils = {
-        version = "2.43.1";
-        hash = "sha256-vsqsXSleA3WHtjpC+tV/49nXuD9HjrJLZ/nuxdDxhy8=";
-      };
-      gcc = {
-        version = "14.2.0";
-        hash = "sha256-p7Obxpy/niWCbFpgqyZHcAH3wI2FzsBLwOKcq+1vPMk=";
-      };
-      newlib = {
-        version = "4.4.0.20231231";
-        hash = "sha256-DBZqOeG/CVHfr81olJ/g5LbTZYCB1igvOa7vxjEPLxM=";
-      };
+      variant = 3;
+      archName = "ARM64";
     };
-    variant = 3;
-    archName = "ARM64";
-  };
-}
+  }
+)

--- a/pkgs/toolchains/wrapper.nix
+++ b/pkgs/toolchains/wrapper.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  stdenvNoCC,
+  makeBinaryWrapper,
+  unwrapped,
+}:
+stdenvNoCC.mkDerivation {
+  pname = unwrapped.pname + "-wrapped";
+  inherit (unwrapped) version;
+
+  nativeBuildInputs = [makeBinaryWrapper];
+
+  dontUnpack = true;
+  dontPatch = true;
+  dontBuild = true;
+  dontConfigure = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    ln -s ${lib.escapeShellArg unwrapped}/bin/* "$out/bin"
+
+    for program in "$out"/bin/*-{gcc,g++,c++}; do
+      wrapProgram "$program" --argv0 ""
+    done
+  '';
+
+  passthru = {
+    inherit unwrapped;
+  };
+
+  inherit (unwrapped) meta;
+}


### PR DESCRIPTION
This is necessary infrastructure to support the C runtime and linker script packages for noobkitARM (devkitarm-crtls, gp2x-core).

Remaining work:
- [ ] actually package the necessary components
- [ ] point wrapper at them (`gcc -B<path>`)
- [ ] testing