### PR TITLE
[7/12] overlays.default: move to by-name structure

### DIFF
--- a/by-name/default/overlay.nix
+++ b/by-name/default/overlay.nix
@@ -2,5 +2,5 @@ final: prev: let
   inherit (final) callPackage lib;
   inherit (lib) recurseIntoAttrs;
 in {
-  devkitNoob = recurseIntoAttrs (callPackage ./pkgs {});
+  devkitNoob = recurseIntoAttrs (callPackage ../../pkgs {});
 }

--- a/flake.nix
+++ b/flake.nix
@@ -59,6 +59,6 @@
       packages = getDerivations packages;
     };
 
-    overlays.default = import ./overlay.nix;
+    overlays.default = import ./by-name/default/overlay.nix;
   };
 }


### PR DESCRIPTION
**Stack:**

* https://github.com/devkitNoob/devkitNoob/pull/6
* https://github.com/devkitNoob/devkitNoob/pull/7
* https://github.com/devkitNoob/devkitNoob/pull/8
* https://github.com/devkitNoob/devkitNoob/pull/9
* https://github.com/devkitNoob/devkitNoob/pull/10
* https://github.com/devkitNoob/devkitNoob/pull/11
* https://github.com/devkitNoob/devkitNoob/pull/12
* https://github.com/devkitNoob/devkitNoob/pull/13
* https://github.com/devkitNoob/devkitNoob/pull/14
* https://github.com/devkitNoob/devkitNoob/pull/15
* https://github.com/devkitNoob/devkitNoob/pull/16
* https://github.com/devkitNoob/devkitNoob/pull/17


---

overlays.default: move to by-name structure

